### PR TITLE
Fix position of kanpai se audio source

### DIFF
--- a/Assets/Prefabs/Mug/Mug.prefab
+++ b/Assets/Prefabs/Mug/Mug.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7911039869776854797}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10.48, y: 1.5, z: 0}
+  m_LocalPosition: {x: 0, y: 1.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8252337865818922472}
@@ -241,6 +241,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344ae230782044a06950331d509e4431, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isPlayer: 0
   playerNum: 0
 --- !u!114 &7510466589175533351
 MonoBehaviour:


### PR DESCRIPTION
特に問題になってなさそうだけど乾杯SEのAudioSourceの位置がめっちゃ後ろだったので直した（ついでに `isPlayer` のデフォルト値も混ざってしまったけどコミットした方がいいかなと思ったのでしてしまった）